### PR TITLE
Optimize lossless JPEG transcoding and reconstruction

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,9 @@ let package = Package(
                 linkerSettings: [
                     .linkedFramework("Accelerate")
                 ]),
+        .testTarget(
+            name: "JxlCoderTests",
+            dependencies: ["JxlCoder"]),
         .binaryTarget(name: "libbrotlicommon", path: "Sources/Frameworks/libbrotlicommon.xcframework"),
         .binaryTarget(name: "libbrotlidec", path: "Sources/Frameworks/libbrotlidec.xcframework"),
         .binaryTarget(name: "libbrotlienc", path: "Sources/Frameworks/libbrotlienc.xcframework"),

--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ let reconstructed = try JXLCoder.inverse(
 
 JPEG transcoding preserves the original JPEG bit-for-bit. `effort` accepts
 values from 1 through 9. `threads` accepts 1 through 256, or 0 to use the
-active processor count. Both options have defaults, so existing
-`transcode(jpegData:)` and `inverse(jxlData:)` calls remain valid.
+active processor count. The original `transcode(jpegData:)` and
+`inverse(jxlData:)` methods remain available with effort 7 and automatic
+worker selection.
 
 ## Jpegli encoding
 

--- a/README.md
+++ b/README.md
@@ -67,12 +67,24 @@ try! animEncoder.add(frame: frameToAnimate, duration: 150)
 let animationJxlData = try! animEncoder.finish()
 ```
 
-## Loseless JPEG transcoding
+## Lossless JPEG transcoding
 
 ```swift
-let transcoded = try! JXLCoder.transcode(jpegData: Data())
-let jpegData: Data = try! JXLCoder.inverse(jxlData: Data())
+let transcoded = try JXLCoder.transcode(
+    jpegData: jpegData,
+    effort: 7,
+    threads: 0
+)
+let reconstructed = try JXLCoder.inverse(
+    jxlData: transcoded,
+    threads: 0
+)
 ```
+
+JPEG transcoding preserves the original JPEG bit-for-bit. `effort` accepts
+values from 1 through 9. `threads` accepts 1 through 256, or 0 to use the
+active processor count. Both options have defaults, so existing
+`transcode(jpegData:)` and `inverse(jxlData:)` calls remain valid.
 
 ## Jpegli encoding
 

--- a/Sources/JxlCoder/JXLCoder.swift
+++ b/Sources/JxlCoder/JXLCoder.swift
@@ -30,7 +30,10 @@ import jxlc
 
 public class JXLCoder {
     private static let shared = JxlInternalCoder()
-    private static let processorCount = max(1, ProcessInfo.processInfo.activeProcessorCount)
+    private static let processorCount = min(
+        256,
+        max(1, ProcessInfo.processInfo.activeProcessorCount)
+    )
     private static let magic1 = Data([0xFF, 0x0A])
     private static let magic2 = Data([0x0, 0x0, 0x0, 0x0C, 0x4A, 0x58, 0x4C, 0x20, 0x0D, 0x0A, 0x87, 0x0A])
 
@@ -110,7 +113,17 @@ public class JXLCoder {
     }
     
     /**
-     Losslessly recompresses JPEG data as JPEG XL.
+     Losslessly recompresses JPEG data as JPEG XL using the default options.
+
+     - Parameter jpegData: Data that contains a JPEG image.
+     - Returns: JPEG XL data containing reconstructable JPEG metadata.
+     */
+    public static func transcode(jpegData: Data) throws -> Data {
+        return try transcode(jpegData: jpegData, effort: 7, threads: 0)
+    }
+
+    /**
+     Losslessly recompresses JPEG data as JPEG XL with explicit options.
 
      - Parameters:
        - jpegData: Data that contains a JPEG image.
@@ -122,7 +135,7 @@ public class JXLCoder {
      */
     public static func transcode(
         jpegData: Data,
-        effort: Int = 7,
+        effort: Int,
         threads: Int = 0
     ) throws -> Data {
         return try JxlConstruction.transcode(
@@ -133,7 +146,17 @@ public class JXLCoder {
     }
 
     /**
-     Reconstructs the original JPEG from losslessly transcoded JPEG XL data.
+     Reconstructs the original JPEG using the default worker count.
+
+     - Parameter jxlData: Data containing a reconstructable JPEG XL image.
+     - Returns: The byte-for-byte reconstructed JPEG data.
+     */
+    public static func inverse(jxlData: Data) throws -> Data {
+        return try inverse(jxlData: jxlData, threads: 0)
+    }
+
+    /**
+     Reconstructs the original JPEG with an explicit worker count.
 
      - Parameters:
        - jxlData: Data containing a reconstructable JPEG XL image.
@@ -141,7 +164,7 @@ public class JXLCoder {
          active processor count.
      - Returns: The byte-for-byte reconstructed JPEG data.
      */
-    public static func inverse(jxlData: Data, threads: Int = 0) throws -> Data {
+    public static func inverse(jxlData: Data, threads: Int) throws -> Data {
         return try JxlConstruction.inverse(
             jxlData,
             threads: resolvedThreads(threads)

--- a/Sources/JxlCoder/JXLCoder.swift
+++ b/Sources/JxlCoder/JXLCoder.swift
@@ -30,6 +30,7 @@ import jxlc
 
 public class JXLCoder {
     private static let shared = JxlInternalCoder()
+    private static let processorCount = max(1, ProcessInfo.processInfo.activeProcessorCount)
     private static let magic1 = Data([0xFF, 0x0A])
     private static let magic2 = Data([0x0, 0x0, 0x0, 0x0C, 0x4A, 0x58, 0x4C, 0x20, 0x0D, 0x0A, 0x87, 0x0A])
 
@@ -108,20 +109,47 @@ public class JXLCoder {
                                  decodingSpeed: decodingSpeed)
     }
     
-    /***
-     - Parameter jpegData: Data that contains JPEG image to transcode into a JXL
-     - Returns: JXL data of the image
-     **/
-    public static func transcode(jpegData: Data) throws -> Data {
-        return try JxlConstruction.transcode(jpegData)
+    /**
+     Losslessly recompresses JPEG data as JPEG XL.
+
+     - Parameters:
+       - jpegData: Data that contains a JPEG image.
+       - effort: Encoder effort in `1...9`. Higher values trade encoding time
+         for potentially smaller output. The default matches libjxl.
+       - threads: Maximum codec worker count in `1...256`, or `0` to use the
+         active processor count.
+     - Returns: JPEG XL data containing reconstructable JPEG metadata.
+     */
+    public static func transcode(
+        jpegData: Data,
+        effort: Int = 7,
+        threads: Int = 0
+    ) throws -> Data {
+        return try JxlConstruction.transcode(
+            jpegData,
+            effort: effort,
+            threads: resolvedThreads(threads)
+        )
     }
 
-    /***
-     - Parameter jxlData: Data that contains JXL image to inverse back into a JPEG
-     - Returns: JPEG data of the image
-     **/
-    public static func inverse(jxlData: Data) throws -> Data {
-        return try JxlConstruction.inverse(jxlData)
+    /**
+     Reconstructs the original JPEG from losslessly transcoded JPEG XL data.
+
+     - Parameters:
+       - jxlData: Data containing a reconstructable JPEG XL image.
+       - threads: Maximum codec worker count in `1...256`, or `0` to use the
+         active processor count.
+     - Returns: The byte-for-byte reconstructed JPEG data.
+     */
+    public static func inverse(jxlData: Data, threads: Int = 0) throws -> Data {
+        return try JxlConstruction.inverse(
+            jxlData,
+            threads: resolvedThreads(threads)
+        )
+    }
+
+    private static func resolvedThreads(_ requested: Int) -> Int {
+        requested == 0 ? processorCount : requested
     }
     
     /***

--- a/Sources/jxlc/JxlConstruction.h
+++ b/Sources/jxlc/JxlConstruction.h
@@ -11,6 +11,13 @@
 
 @interface JxlConstruction : NSObject
 +(nullable NSData*)transcode:(nonnull NSData*)data error:(NSError * _Nullable *_Nullable)error;
++(nullable NSData*)transcode:(nonnull NSData*)data
+                      effort:(NSInteger)effort
+                     threads:(NSInteger)threads
+                       error:(NSError * _Nullable *_Nullable)error;
 +(nullable NSData*)inverse:(nonnull NSData*)data error:(NSError * _Nullable *_Nullable)error;
++(nullable NSData*)inverse:(nonnull NSData*)data
+                     threads:(NSInteger)threads
+                       error:(NSError * _Nullable *_Nullable)error;
 
 @end

--- a/Sources/jxlc/JxlConstruction.mm
+++ b/Sources/jxlc/JxlConstruction.mm
@@ -106,10 +106,8 @@ class OutputBuffer {
 };
 
 NSInteger DefaultThreadCount() {
-  static const NSInteger processorCount = std::max<NSInteger>(
-      1,
-      NSProcessInfo.processInfo.activeProcessorCount
-  );
+  static const NSInteger processorCount = std::clamp<NSInteger>(
+      NSProcessInfo.processInfo.activeProcessorCount, 1, kMaximumThreadCount);
   return processorCount;
 }
 

--- a/Sources/jxlc/JxlConstruction.mm
+++ b/Sources/jxlc/JxlConstruction.mm
@@ -1,84 +1,333 @@
 //
 //  JxlConstruction.m
-//  
+//
 //
 //  Created by Radzivon Bartoshyk on 21/03/2024.
 //
 
 #import <Foundation/Foundation.h>
-#import "JxlConstruction.h"
-#import "JxlTranscode.hpp"
-#import "JxlJpegInverse.hpp"
+#import <dispatch/dispatch.h>
 
-template <typename DataType>
-class JxlConstructionDataWrapper {
-public:
-    JxlConstructionDataWrapper() {}
-    std::vector<DataType> data;
+#import "JxlConstruction.h"
+
+#include "jxl/decode.h"
+#include "jxl/decode_cxx.h"
+#include "jxl/encode.h"
+#include "jxl/encode_cxx.h"
+#include "jxl/parallel_runner.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <limits>
+#include <new>
+
+namespace {
+
+constexpr NSInteger kMaximumThreadCount = 256;
+
+struct RunnerConfiguration {
+  size_t threadCount;
 };
 
-@implementation JxlConstruction {
-    
+struct ParallelWork {
+  void *jpegxlOpaque;
+  JxlParallelRunFunction function;
+  uint32_t start;
+  uint32_t end;
+  size_t threadCount;
+};
+
+void RunWorker(void *context, size_t threadIndex) {
+  auto *work = static_cast<ParallelWork *>(context);
+  for (uint32_t value = work->start + static_cast<uint32_t>(threadIndex);
+       value < work->end; value += static_cast<uint32_t>(work->threadCount)) {
+    work->function(work->jpegxlOpaque, value, threadIndex);
+  }
 }
 
-+(nullable NSData*)transcode:(nonnull NSData*)data error:(NSError * _Nullable *_Nullable)error {
-    try {
-        std::vector<uint8_t> source([data length]);
-        auto srcBytes = reinterpret_cast<const uint8_t*>([data bytes]);
-        std::copy(srcBytes, srcBytes + [data length], source.begin());
-        jxlcoder::JxlConstruction contruction(source);
-        if (!contruction.construct()) {
-            *error = [[NSError alloc] initWithDomain:@"JXLCoder"
-                                                code:500
-                                            userInfo:@{ NSLocalizedDescriptionKey: @"Cannot transcode provided 'JPEG' data into JXL" }];
-            return nullptr;
-        }
-        JxlConstructionDataWrapper<uint8_t>* dataWrapper = new JxlConstructionDataWrapper<uint8_t>();
-        dataWrapper->data = contruction.getCompressedData();
-        
-        auto data = [[NSData alloc] initWithBytesNoCopy:dataWrapper->data.data()
-                                                 length:dataWrapper->data.size()
-                                            deallocator:^(void * _Nonnull bytes, NSUInteger length) {
-            delete dataWrapper;
-        }];
-        
-        return data;
-    } catch (std::bad_alloc &err) {
-        *error = [[NSError alloc] initWithDomain:@"JXLCoder"
-                                            code:500
-                                        userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Transcoding an image error: %s", err.what()] }];
-        return nullptr;
-    }
+JxlParallelRetCode DispatchParallelRunner(
+    void *runnerOpaque, void *jpegxlOpaque, JxlParallelRunInit initialize,
+    JxlParallelRunFunction function, uint32_t start, uint32_t end) {
+  const auto *configuration =
+      static_cast<const RunnerConfiguration *>(runnerOpaque);
+  const size_t itemCount = end - start;
+  const size_t threadCount =
+      std::max<size_t>(1, std::min(configuration->threadCount, itemCount));
+  const JxlParallelRetCode initialization =
+      initialize(jpegxlOpaque, threadCount);
+  if (initialization != JXL_PARALLEL_RET_SUCCESS || itemCount == 0) {
+    return initialization;
+  }
+
+  ParallelWork work{jpegxlOpaque, function, start, end, threadCount};
+  if (threadCount == 1) {
+    RunWorker(&work, 0);
+  } else {
+    dispatch_apply_f(
+        threadCount,
+        dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0),
+        &work,
+        RunWorker
+    );
+  }
+  return JXL_PARALLEL_RET_SUCCESS;
 }
 
-+(nullable NSData*)inverse:(nonnull NSData*)data error:(NSError * _Nullable *_Nullable)error {
-    try {
-        std::vector<uint8_t> source([data length]);
-        auto srcBytes = reinterpret_cast<const uint8_t*>([data bytes]);
-        std::copy(srcBytes, srcBytes + [data length], source.begin());
-        jxlcoder::JxlInverse contruction(source);
-        if (!contruction.inverse()) {
-            *error = [[NSError alloc] initWithDomain:@"JXLCoder"
-                                                code:500
-                                            userInfo:@{ NSLocalizedDescriptionKey: @"Cannot inverse provided 'JXL' data into JPEG" }];
-            return nullptr;
-        }
-        JxlConstructionDataWrapper<uint8_t>* dataWrapper = new JxlConstructionDataWrapper<uint8_t>();
-        dataWrapper->data = contruction.getJPEGData();
-        
-        auto data = [[NSData alloc] initWithBytesNoCopy:dataWrapper->data.data()
-                                                 length:dataWrapper->data.size()
-                                            deallocator:^(void * _Nonnull bytes, NSUInteger length) {
-            delete dataWrapper;
-        }];
-        
-        return data;
-    } catch (std::bad_alloc &err) {
-        *error = [[NSError alloc] initWithDomain:@"JXLCoder"
-                                            code:500
-                                        userInfo:@{ NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Inverse JPEG has signalled an error: %s", err.what()] }];
-        return nullptr;
+class OutputBuffer {
+ public:
+  explicit OutputBuffer(size_t capacity)
+      : bytes_(static_cast<uint8_t *>(std::malloc(capacity))),
+        capacity_(bytes_ == nullptr ? 0 : capacity) {}
+  ~OutputBuffer() { std::free(bytes_); }
+
+  uint8_t *bytes() const { return bytes_; }
+  size_t capacity() const { return capacity_; }
+
+  bool Grow() {
+    if (capacity_ == 0 ||
+        capacity_ > std::numeric_limits<size_t>::max() / 2) {
+      return false;
     }
+    const size_t newCapacity = capacity_ * 2;
+    void *newBytes = std::realloc(bytes_, newCapacity);
+    if (newBytes == nullptr) {
+      return false;
+    }
+    bytes_ = static_cast<uint8_t *>(newBytes);
+    capacity_ = newCapacity;
+    return true;
+  }
+
+ private:
+  uint8_t *bytes_;
+  size_t capacity_;
+};
+
+NSInteger DefaultThreadCount() {
+  static const NSInteger processorCount = std::max<NSInteger>(
+      1,
+      NSProcessInfo.processInfo.activeProcessorCount
+  );
+  return processorCount;
+}
+
+void SetError(NSError **error, NSString *message, NSInteger code = 500) {
+  if (error != nullptr) {
+    *error = [NSError errorWithDomain:@"JXLCoder"
+                                 code:code
+                             userInfo:@{NSLocalizedDescriptionKey : message}];
+  }
+}
+
+OutputBuffer *CreateBuffer(size_t capacity, NSError **error,
+                           NSString *message) {
+  auto *buffer = new (std::nothrow) OutputBuffer(capacity);
+  if (buffer == nullptr || buffer->bytes() == nullptr) {
+    SetError(error, message);
+    delete buffer;
+    return nullptr;
+  }
+  return buffer;
+}
+
+}  // namespace
+
+@implementation JxlConstruction
+
++ (nullable NSData *)transcode:(NSData *)data
+                          error:(NSError *_Nullable *_Nullable)error {
+  return [self transcode:data
+                  effort:7
+                 threads:DefaultThreadCount()
+                   error:error];
+}
+
++ (nullable NSData *)transcode:(NSData *)data
+                         effort:(NSInteger)effort
+                        threads:(NSInteger)threads
+                          error:(NSError *_Nullable *_Nullable)error {
+  if (effort < 1 || effort > 9 || threads < 1 ||
+      threads > kMaximumThreadCount) {
+    SetError(error, @"effort must be 1...9 and threads must be 1...256", 400);
+    return nil;
+  }
+
+  auto encoder = JxlEncoderMake(nullptr);
+  if (encoder == nullptr) {
+    SetError(error, @"Failed to create the JPEG XL encoder");
+    return nil;
+  }
+  RunnerConfiguration runner{static_cast<size_t>(threads)};
+  if (JxlEncoderSetParallelRunner(
+          encoder.get(), DispatchParallelRunner, &runner) != JXL_ENC_SUCCESS ||
+      JxlEncoderStoreJPEGMetadata(encoder.get(), JXL_TRUE) != JXL_ENC_SUCCESS) {
+    SetError(error, @"Failed to configure the JPEG XL encoder");
+    return nil;
+  }
+
+  JxlEncoderFrameSettings *settings =
+      JxlEncoderFrameSettingsCreate(encoder.get(), nullptr);
+  if (settings == nullptr ||
+      JxlEncoderSetFrameLossless(settings, JXL_TRUE) != JXL_ENC_SUCCESS ||
+      JxlEncoderFrameSettingsSetOption(
+          settings, JXL_ENC_FRAME_SETTING_EFFORT, effort) != JXL_ENC_SUCCESS ||
+      JxlEncoderFrameSettingsSetOption(
+          settings, JXL_ENC_FRAME_SETTING_DECODING_SPEED, 3) !=
+          JXL_ENC_SUCCESS ||
+      JxlEncoderAddJPEGFrame(
+          settings,
+          static_cast<const uint8_t *>(data.bytes),
+          data.length) != JXL_ENC_SUCCESS) {
+    SetError(
+        error,
+        [NSString stringWithFormat:@"JPEG transcoding failed (%d)",
+                                   JxlEncoderGetError(encoder.get())]
+    );
+    return nil;
+  }
+
+  JxlEncoderCloseInput(encoder.get());
+  OutputBuffer *output = CreateBuffer(
+      std::max<NSUInteger>(data.length, 4096),
+      error,
+      @"Failed to allocate the JPEG XL output buffer"
+  );
+  if (output == nullptr) {
+    return nil;
+  }
+
+  uint8_t *nextOutput = output->bytes();
+  size_t availableOutput = output->capacity();
+  JxlEncoderStatus status = JXL_ENC_NEED_MORE_OUTPUT;
+  while (status == JXL_ENC_NEED_MORE_OUTPUT) {
+    status = JxlEncoderProcessOutput(
+        encoder.get(), &nextOutput, &availableOutput);
+    if (status == JXL_ENC_NEED_MORE_OUTPUT) {
+      const size_t offset = nextOutput - output->bytes();
+      if (!output->Grow()) {
+        SetError(error, @"Failed to grow the JPEG XL output buffer");
+        delete output;
+        return nil;
+      }
+      nextOutput = output->bytes() + offset;
+      availableOutput = output->capacity() - offset;
+    }
+  }
+
+  if (status != JXL_ENC_SUCCESS) {
+    SetError(
+        error,
+        [NSString stringWithFormat:@"JPEG transcoding failed (%d)",
+                                   JxlEncoderGetError(encoder.get())]
+    );
+    delete output;
+    return nil;
+  }
+
+  const size_t outputSize = nextOutput - output->bytes();
+  return [[NSData alloc]
+      initWithBytesNoCopy:output->bytes()
+                  length:outputSize
+             deallocator:^(void *, NSUInteger) {
+               delete output;
+             }];
+}
+
++ (nullable NSData *)inverse:(NSData *)data
+                        error:(NSError *_Nullable *_Nullable)error {
+  return [self inverse:data threads:DefaultThreadCount() error:error];
+}
+
++ (nullable NSData *)inverse:(NSData *)data
+                       threads:(NSInteger)threads
+                         error:(NSError *_Nullable *_Nullable)error {
+  if (threads < 1 || threads > kMaximumThreadCount) {
+    SetError(error, @"threads must be 1...256", 400);
+    return nil;
+  }
+
+  auto decoder = JxlDecoderMake(nullptr);
+  if (decoder == nullptr) {
+    SetError(error, @"Failed to create the JPEG XL decoder");
+    return nil;
+  }
+  RunnerConfiguration runner{static_cast<size_t>(threads)};
+  if (JxlDecoderSetParallelRunner(
+          decoder.get(), DispatchParallelRunner, &runner) != JXL_DEC_SUCCESS ||
+      JxlDecoderSubscribeEvents(
+          decoder.get(), JXL_DEC_JPEG_RECONSTRUCTION | JXL_DEC_FULL_IMAGE) !=
+          JXL_DEC_SUCCESS ||
+      JxlDecoderSetInput(
+          decoder.get(), static_cast<const uint8_t *>(data.bytes), data.length) !=
+          JXL_DEC_SUCCESS) {
+    SetError(error, @"Failed to configure JPEG reconstruction");
+    return nil;
+  }
+  JxlDecoderCloseInput(decoder.get());
+
+  JxlDecoderStatus status = JxlDecoderProcessInput(decoder.get());
+  if (status != JXL_DEC_JPEG_RECONSTRUCTION) {
+    SetError(error, @"The JXL stream has no reconstructable JPEG payload");
+    return nil;
+  }
+
+  const size_t initialCapacity = data.length > NSUIntegerMax / 2
+      ? NSUIntegerMax
+      : std::max<NSUInteger>(data.length * 2, 4096);
+  OutputBuffer *output = CreateBuffer(
+      initialCapacity,
+      error,
+      @"Failed to allocate the JPEG reconstruction buffer"
+  );
+  if (output == nullptr) {
+    return nil;
+  }
+  if (JxlDecoderSetJPEGBuffer(
+          decoder.get(), output->bytes(), output->capacity()) !=
+      JXL_DEC_SUCCESS) {
+    SetError(error, @"Failed to configure the JPEG reconstruction buffer");
+    delete output;
+    return nil;
+  }
+
+  size_t used = 0;
+  while (true) {
+    status = JxlDecoderProcessInput(decoder.get());
+    if (status == JXL_DEC_JPEG_NEED_MORE_OUTPUT) {
+      used = output->capacity() -
+             JxlDecoderReleaseJPEGBuffer(decoder.get());
+      if (!output->Grow()) {
+        SetError(error, @"Failed to grow the JPEG reconstruction buffer");
+        delete output;
+        return nil;
+      }
+      if (JxlDecoderSetJPEGBuffer(
+              decoder.get(), output->bytes() + used,
+              output->capacity() - used) != JXL_DEC_SUCCESS) {
+        SetError(error, @"Failed to grow the JPEG reconstruction buffer");
+        delete output;
+        return nil;
+      }
+      continue;
+    }
+    break;
+  }
+
+  if (status != JXL_DEC_FULL_IMAGE && status != JXL_DEC_SUCCESS) {
+    SetError(error, @"Failed to reconstruct JPEG data");
+    delete output;
+    return nil;
+  }
+
+  used = output->capacity() - JxlDecoderReleaseJPEGBuffer(decoder.get());
+  return [[NSData alloc]
+      initWithBytesNoCopy:output->bytes()
+                  length:used
+             deallocator:^(void *, NSUInteger) {
+               delete output;
+             }];
 }
 
 @end

--- a/Tests/JxlCoderTests/JpegTranscodingTests.swift
+++ b/Tests/JxlCoderTests/JpegTranscodingTests.swift
@@ -3,6 +3,16 @@ import XCTest
 import JxlCoder
 
 final class JpegTranscodingTests: XCTestCase {
+    func testOriginalAPIFunctionReferencesRemainAvailable() throws {
+        let transcode: (Data) throws -> Data = JXLCoder.transcode
+        let inverse: (Data) throws -> Data = JXLCoder.inverse
+
+        let jxl = try transcode(Self.jpegFixture)
+        let reconstructed = try inverse(jxl)
+
+        XCTAssertEqual(reconstructed, Self.jpegFixture)
+    }
+
     func testDefaultAPIReconstructsOriginalJPEG() throws {
         let jpeg = Self.jpegFixture
 
@@ -57,6 +67,24 @@ final class JpegTranscodingTests: XCTestCase {
         wait(for: [finished], timeout: 30)
     }
 
+    func testReconstructionGrowsOutputBuffer() throws {
+        let jpeg = Self.jpegFixtureWithCompressibleMetadata
+
+        let jxl = try JXLCoder.transcode(
+            jpegData: jpeg,
+            effort: 7,
+            threads: 1
+        )
+        XCTAssertGreaterThan(
+            jpeg.count,
+            max(jxl.count * 2, 4096),
+            "fixture must exceed the reconstruction buffer's initial capacity"
+        )
+
+        let reconstructed = try JXLCoder.inverse(jxlData: jxl, threads: 1)
+        XCTAssertEqual(reconstructed, jpeg)
+    }
+
     func testInvalidOptionsAndInputThrow() throws {
         let jpeg = Self.jpegFixture
 
@@ -73,9 +101,34 @@ final class JpegTranscodingTests: XCTestCase {
             try JXLCoder.transcode(jpegData: jpeg, effort: 7, threads: 257)
         )
         XCTAssertThrowsError(
+            try JXLCoder.transcode(
+                jpegData: Data([0, 1, 2]),
+                effort: 7,
+                threads: 1
+            )
+        )
+        XCTAssertThrowsError(
             try JXLCoder.inverse(jxlData: Data([0, 1, 2]), threads: 1)
         )
     }
+
+    private static let jpegFixtureWithCompressibleMetadata: Data = {
+        let commentPayloadLength = 60_000
+        let commentSegmentLength = commentPayloadLength + 2
+        var jpeg = Data([0xFF, 0xD8])
+
+        for _ in 0..<4 {
+            jpeg.append(contentsOf: [
+                0xFF,
+                0xFE,
+                UInt8(commentSegmentLength >> 8),
+                UInt8(commentSegmentLength & 0xFF),
+            ])
+            jpeg.append(Data(repeating: 0, count: commentPayloadLength))
+        }
+        jpeg.append(jpegFixture.dropFirst(2))
+        return jpeg
+    }()
 
     private static let jpegFixture = Data(
         base64Encoded: jpegBase64,

--- a/Tests/JxlCoderTests/JpegTranscodingTests.swift
+++ b/Tests/JxlCoderTests/JpegTranscodingTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import XCTest
+import JxlCoder
+
+final class JpegTranscodingTests: XCTestCase {
+    func testDefaultAPIReconstructsOriginalJPEG() throws {
+        let jpeg = Self.jpegFixture
+
+        let jxl = try JXLCoder.transcode(jpegData: jpeg)
+        let reconstructed = try JXLCoder.inverse(jxlData: jxl)
+
+        XCTAssertFalse(jxl.isEmpty)
+        XCTAssertEqual(reconstructed, jpeg)
+    }
+
+    func testEffortAndThreadOptionsReconstructOriginalJPEG() throws {
+        let jpeg = Self.jpegFixture
+
+        for effort in [1, 7, 9] {
+            let jxl = try JXLCoder.transcode(
+                jpegData: jpeg,
+                effort: effort,
+                threads: 1
+            )
+            let reconstructed = try JXLCoder.inverse(
+                jxlData: jxl,
+                threads: 1
+            )
+            XCTAssertEqual(reconstructed, jpeg, "effort \(effort)")
+        }
+    }
+
+    func testConcurrentRoundTripsAreIndependent() {
+        let finished = expectation(description: "concurrent round trips")
+        finished.expectedFulfillmentCount = 4
+
+        for effort in [1, 3, 7, 9] {
+            DispatchQueue.global(qos: .userInitiated).async {
+                defer { finished.fulfill() }
+                do {
+                    let jxl = try JXLCoder.transcode(
+                        jpegData: Self.jpegFixture,
+                        effort: effort,
+                        threads: 2
+                    )
+                    let reconstructed = try JXLCoder.inverse(
+                        jxlData: jxl,
+                        threads: 2
+                    )
+                    XCTAssertEqual(reconstructed, Self.jpegFixture)
+                } catch {
+                    XCTFail("effort \(effort) failed: \(error)")
+                }
+            }
+        }
+
+        wait(for: [finished], timeout: 30)
+    }
+
+    func testInvalidOptionsAndInputThrow() throws {
+        let jpeg = Self.jpegFixture
+
+        XCTAssertThrowsError(
+            try JXLCoder.transcode(jpegData: jpeg, effort: 0, threads: 1)
+        )
+        XCTAssertThrowsError(
+            try JXLCoder.transcode(jpegData: jpeg, effort: 10, threads: 1)
+        )
+        XCTAssertThrowsError(
+            try JXLCoder.transcode(jpegData: jpeg, effort: 7, threads: -1)
+        )
+        XCTAssertThrowsError(
+            try JXLCoder.transcode(jpegData: jpeg, effort: 7, threads: 257)
+        )
+        XCTAssertThrowsError(
+            try JXLCoder.inverse(jxlData: Data([0, 1, 2]), threads: 1)
+        )
+    }
+
+    private static let jpegFixture = Data(
+        base64Encoded: jpegBase64,
+        options: .ignoreUnknownCharacters
+    )!
+
+    private static let jpegBase64 = """
+    /9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJChQODwwQFxQYGBcUFhYaHSUfGhsjHBYWICwg
+    IyYnKSopGR8tMC0oMCUoKSj/2wBDAQcHBwoIChMKChMoGhYaKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgo
+    KCgoKCgoKCgoKCgoKCj/wAARCAAIAAgDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAH/xAAXEAEAAwAAAAAAAAAA
+    AAAAAAAAF2Oh/8QAFAEBAAAAAAAAAAAAAAAAAAAABf/EABkRAAIDAQAAAAAAAAAAAAAAAABRAwQUFf/aAAwDAQACEQMRAD8A
+    sa04AF6VhiWGFH//2Q==
+    """
+}


### PR DESCRIPTION
## Summary

Improve lossless JPEG-to-JXL transcoding and JPEG reconstruction by removing redundant native copies and repeated tiny output-buffer growth, using a Grand Central Dispatch-backed libjxl runner, and exposing configurable effort/thread controls through the Swift API.

The exact pre-existing Swift overloads remain available:

```swift
try JXLCoder.transcode(jpegData: jpegData)
try JXLCoder.inverse(jxlData: jxlData)
```

Callers that need explicit control can use:

```swift
try JXLCoder.transcode(jpegData: jpegData, effort: 7, threads: 0)
try JXLCoder.inverse(jxlData: jxlData, threads: 0)
```

`threads: 0` uses a cached active processor count clamped to the supported `1...256` range. Explicit thread counts accept `1...256`, and encoder effort accepts `1...9`.

## Motivation

This work came from profiling lossless JPEG conversion in a downstream Flutter integration. The existing native path performs several avoidable operations around the actual libjxl work:

- input `NSData` is copied into a `std::vector`, then copied again into the codec helper;
- transcode output starts at 64 bytes and reconstructed JPEG output at 128 bytes, causing repeated allocation, copying, and value-initialization while the vectors double;
- encoded output is copied again into the owner used by the returned `NSData`;
- the encoder constructs a libjxl `std::thread` runner for every conversion;
- the inverse path constructs a resizable runner but does not attach it to the decoder; and
- effort and thread choices are fixed inside the implementation, preventing callers from coordinating per-image parallelism with higher-level batching.

These costs become more visible for large JPEGs and when several conversions run concurrently.

## Changes

### Native buffer and ownership path

- Pass the input `NSData` bytes directly to libjxl for the duration of the synchronous call.
- Pre-size encoder output from the JPEG input size and reconstruction output from twice the JXL size.
- Use checked `malloc`/`realloc` storage so capacity is not explicitly zero-filled before libjxl overwrites it.
- Grow geometrically when the initial estimate is insufficient.
- Return only the logical output length through zero-copy `NSData`, with a deallocator that owns the native allocation.
- Check initial allocation failure, reallocation failure, capacity overflow, and reconstruction-size overflow.
- Avoid dereferencing a null `NSError **` on error paths.

### Parallel execution and options

- Use a GCD-backed `JxlParallelRunner` for both encoding and reconstruction instead of creating a native thread pool for every image.
- Retain the exact original Swift one-argument overloads and add configurable effort/thread overloads.
- Preserve the original Objective-C selectors and add explicit effort/thread variants.
- Cache and defensively clamp automatic processor-count resolution.

### Tests and documentation

- Add a SwiftPM test target.
- Verify byte-for-byte JPEG reconstruction through the original default API.
- Verify the original methods remain assignable to `(Data) throws -> Data` function references.
- Exercise efforts 1, 7, and 9 with explicit thread control.
- Exercise concurrent independent round trips using the GCD runner.
- Force reconstruction output-buffer growth with highly compressible JPEG metadata, then verify byte-for-byte output.
- Verify invalid options, malformed JPEG input, and malformed JXL input throw errors.
- Document the configurable overloads while keeping the simple usage visible.

## Compatibility

- The exact original Swift `transcode(jpegData:)` and `inverse(jxlData:)` overloads and symbols remain available.
- Existing Objective-C `transcode:error:` and `inverse:error:` selectors remain available.
- The default effort remains 7 and the encoder decoding-speed setting remains 3.
- The resulting JXL remains losslessly reconstructable to the exact original JPEG bytes.
- The existing C++ headers remain present for consumers that may include them directly.

## Validation

- `swift build` on macOS: passed
- `swift test`: 6 tests passed
- `swift test --sanitize address`: 6 tests passed with AddressSanitizer
- arm64 iOS 13 cross-build using the iPhoneOS 18.4 SDK: passed

Timing varies substantially with system load, especially for concurrent work, so this PR avoids presenting a universal percentage claim. The deterministic improvement is the removal of redundant copies, zero-initialization passes, repeated small-buffer growth, and per-call thread-pool construction; applications should benchmark their own image sizes and concurrency patterns.

